### PR TITLE
Change youtube thumbnail source

### DIFF
--- a/util.py
+++ b/util.py
@@ -63,7 +63,7 @@ def img_to_streaming_response(image: Image):
 
 
 def get_youtube_thumbnail(video_id: str):
-    return read_img_from_url(f"https://i.ytimg.com/vi_webp/{video_id}/mqdefault.webp")
+    return read_img_from_url(f"https://img.youtube.com/vi/{video_id}/maxresdefault.jpg")
 
 
 def get_vimeo_thumbnail(video_id: str):

--- a/util.py
+++ b/util.py
@@ -35,6 +35,11 @@ def read_img_from_url(url: str):
 def add_play_button_to_thumbnail(thumbnail: Image, play_button_path: str):
     #Read images
     play = Image.open(play_button_path).convert("RGBA")
+    #Resize play button
+    play_size_ideal = (int(thumbnail.width/4.75), int(thumbnail.width/4.75*0.7))
+    play_size_max = (132, 84)
+    play_size_new = min(play_size_ideal[0], play_size_max[0]), min(play_size_ideal[1], play_size_max[1])
+    play = play.resize(play_size_new)
     #Create backdrop
     backdrop = Image.open('img/backdrop.png')
     #Resize backdrop


### PR DESCRIPTION
fix #39
Quick fix. 

A better solution would be to only fetch the full size image if it's above a certain resolution, so we don't always fetch the full sized image