### PR TITLE
Add support for YouTube shorts in the YouTube regexp

### DIFF
--- a/apps/api/src/util.py
+++ b/apps/api/src/util.py
@@ -15,7 +15,7 @@ class Supported_Filetype(str, Enum):
 
 
 class URL_Regex(str, Enum):
-    YOUTUBE = r"^(?:(?:https?://(?:www\.)?(?:m\.)?youtube\.com))/(?:(?:oembed\?url=https?%3A//(?:www\.)youtube.com/watch\?(?:v%3D)(?P<video_id_1>[A-Za-z0-9_\-]{11}))|(?:attribution_link\?a=.*watch(?:%3Fv%3D|%3Fv%3D)(?P<video_id_2>[A-Za-z0-9_\-]{11}))).*|(?:https?:)?(?:\/\/)?(?:(?:www\.|m\.)?youtube(?:-nocookie)?\.com\/(?:(?:watch)?\?(?:app=desktop&)?(?:feature=\w*&)?v=|embed\/|v\/|e\/)|youtu\.be\/)(?P<video_id_3>[A-Za-z0-9_\-]{11}).*$"
+    YOUTUBE = r"^(?:(?:https?://(?:www\.)?(?:m\.)?youtube\.com))/(?:(?:oembed\?url=https?%3A//(?:www\.)youtube.com/watch\?(?:v%3D)(?P<video_id_1>[A-Za-z0-9_\-]{11}))|(?:attribution_link\?a=.*watch(?:%3Fv%3D|%3Fv%3D)(?P<video_id_2>[A-Za-z0-9_\-]{11}))).*|(?:https?:)?(?:\/\/)?(?:(?:www\.|m\.)?youtube(?:-nocookie)?\.com\/(?:(?:watch)?\?(?:app=desktop&)?(?:feature=\w*&)?v=|embed\/|v\/|e\/|shorts\/)|youtu\.be\/)(?P<video_id_3>[A-Za-z0-9_\-]{11}).*$"
     """Matches all valid youtube url formats in this list: https://gist.github.com/Snailedlt/d54514e37dda68fefe15e6e056b30747"""
     VIMEO = r"(https?://)?(www.)?(player.)?vimeo.com/([a-z]*/)*(.*/)?(?P<video_id>[0-9]{6,11})[?]?.*"
 

--- a/apps/api/tests/data_for_testing.py
+++ b/apps/api/tests/data_for_testing.py
@@ -288,6 +288,18 @@ active_youtube_array_url_formats = [
     ("https://www.youtube.com/e/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
     ("https://youtube.com/e/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
     ("https://m.youtube.com/e/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("http://www.youtube.com/shorts/j9rZxAF3C0I", "j9rZxAF3C0I"),
+    ("http://youtube.com/shorts/j9rZxAF3C0I", "j9rZxAF3C0I"),
+    ("http://m.youtube.com/shorts/j9rZxAF3C0I", "j9rZxAF3C0I"),
+    ("https://www.youtube.com/shorts/j9rZxAF3C0I", "j9rZxAF3C0I"),
+    ("https://youtube.com/shorts/j9rZxAF3C0I", "j9rZxAF3C0I"),
+    ("https://m.youtube.com/shorts/j9rZxAF3C0I", "j9rZxAF3C0I"),
+    ("http://www.youtube.com/shorts/j9rZxAF3C0I?app=desktop", "j9rZxAF3C0I"),
+    ("http://youtube.com/shorts/j9rZxAF3C0I?app=desktop", "j9rZxAF3C0I"),
+    ("http://m.youtube.com/shorts/j9rZxAF3C0I?app=desktop", "j9rZxAF3C0I"),
+    ("https://www.youtube.com/shorts/j9rZxAF3C0I?app=desktop", "j9rZxAF3C0I"),
+    ("https://youtube.com/shorts/j9rZxAF3C0I?app=desktop", "j9rZxAF3C0I"),
+    ("https://m.youtube.com/shorts/j9rZxAF3C0I?app=desktop", "j9rZxAF3C0I"),
 ]
 
 active_vimeo_array_url_formats = [


### PR DESCRIPTION
This PR addresses issue #206 

### Overview

-  Update the regex to add support for YouTube shorts

### Testing

![Screenshot 2024-09-29 023356](https://github.com/user-attachments/assets/18d69f0d-f297-4ee6-a4b0-0484b72d53c1)
